### PR TITLE
Add NEC MultiSync LCD2070VX

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 | NEC | 1970NXp | | 19 | Partial | The "p" is for PVA. Interlaced modes don't work properly. | |
 | NEC | 1970VX | | 19 | Yes | Med Res loses some horizontal pixels. Has H.Size, V.position, and H.position adjustments, but not V.Size. (for ATARI ST) | |
 | NEC | 1990FXP | | 19 | Yes | | |
+| NEC | 2070VX | | 20 | No | Out of Range | New! |
 | NEC | 2170NX | | 21 | No | | |
 | NEC | 51V | | 15 | Partial | Laced modes cause flickering. | |
 | NEC | 71V | | 17 | Yes | Fully supported, but 480i flicker is annoying and my copy of the screen (rev. 1G) has faint vertical banding in 15 kHz modes. Narrow viewing angle. | |


### PR DESCRIPTION
Adding results of NEC MultiSync LCD2070VX, tested with an NTSC Amiga system.  Display shows "Out of Range".
Followed naming convention in the existing list (dropped "MultiSync" and "LCD" prefix)